### PR TITLE
Fixed avatar url when updating profile

### DIFF
--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -84,6 +84,8 @@ export function AccountPage() {
       if (error) {
         throw error;
       }
+
+      setProfile({ ...profile, avatar_url })
     } catch (error: any) {
       showToast({ message: error.message, duration: 5000 });
     } finally {
@@ -100,7 +102,7 @@ export function AccountPage() {
 
       <IonContent>
         <Avatar url={profile.avatar_url} onUpload={updateProfile}></Avatar>
-        <form onSubmit={updateProfile}>
+        <form onSubmit={(e) => updateProfile(e, profile.avatar_url)}>
           <IonItem>
             <IonLabel>
               <p>Email</p>


### PR DESCRIPTION
The first addition makes it so that you do not need to refresh the page to see your newly uploaded avatar.
On form submission it was previously setting the avatar url as an empty string by default, now it will maintain the same url across profile updates.